### PR TITLE
fix package build-types command

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"coverage-ci": "nyc --reporter=lcov --reporter=text-summary mocha --exit --recursive tests/",
 		"coverage": "nyc npm test",
 		"lint": "eslint lib/ tests/",
-		"build-types": "tsc lib/index.js --declaration --allowJs --emitDeclarationOnly --outDir types",
+		"build-types": "tsc lib/index.js --declaration --allowJs --emitDeclarationOnly --outDir types --skipLibCheck",
 		"prepare": "husky install"
 	},
 	"files": [


### PR DESCRIPTION
Se ajusto el comando de build-types del package.json para que no buildee los types de las dependencias.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved build process to speed up TypeScript compilation and reduce potential errors from external type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->